### PR TITLE
Fix argparse usage compatibility with python3.6

### DIFF
--- a/src/peakrdl/main.py
+++ b/src/peakrdl/main.py
@@ -59,13 +59,16 @@ def main() -> None:
     subgroup = parser.add_subparsers(
         title="subcommands",
         metavar="<subcommand>",
-        required=True
     )
     for subcommand in subcommands:
         subcommand._init_subparser(subgroup)
 
     # Execute!
     options = parser.parse_args()
+    if not hasattr(options, 'subcommand'):
+        parser.print_usage()
+        print(f"{parser.prog}: error the following arguments are required: <subcommand>")
+        sys.exit(1)
     try:
         options.subcommand.main(options)
     except RDLCompileError:


### PR DESCRIPTION
The 'required' argument to add_subparsers was only added in python3.7
Work around by implementing the same functionality manually.

Otherwise the manifest in setup.py should chage python_requires to '>=3.7',