### PR TITLE
Add PeakRDL-etana, verilog without structs

### DIFF
--- a/docs/community.rst
+++ b/docs/community.rst
@@ -84,6 +84,10 @@ RTL Generators
         - `lowRISC <https://github.com/lowRISC>`_
         - Generate OpenTitan register block SystemVerilog from SystemRDL files.
 
+    *   - `PeakRDL-etana <https://peakrdl-etana.readthedocs.io>`_
+        - `Dave Keeshan <https://github.com/davekeeshan>`_
+        - Verilog generator without structs, made explictly work with the icarus compiler
+
 
 
 Documentation


### PR DESCRIPTION
I do a lot of work in the OpenEDA space with FPGAs, which means I mainly work with icarus, which as of now has no support for structs. So [etana ](https://en.wikipedia.org/wiki/Etana) is designed to work explictly with icarus.

I mainly work with emulating asic's on to fpga's including full SoC designs including Arm, RiscV etc.  WIth some many tools, (vivado, protocomiler, synplify, xcleium, vsim, modelsim etc etc) one has a tendancy to have to reduce code back to eh simpler form, there is nearly always one tool that doesn't do some fancy feature.

Testing has been copied over form `PeakRDL-regblock`, but rewritten as cocotb testing

Verilator does support structs but has compile issues with the xilinx unisims primitives.

This code has been tested and works with icarus, verilator, yosys and xcelium.

In addition i was able to test the verilog generated by regblock with the same cocotb testing.  It was complicated by the fact that even though toplevel structs are supposed to be visible as flatten signals at the top, that is not working in verilator.  So there is also a script that generates a top-level wrapper to go around the regblock.sv and connect up the structs into a flatten top-level.  This script can be found the `hwif_wrapper_tool` under `tests`

All testing also have a full CI testing under [github actions](https://github.com/daxzio/PeakRDL-etana/actions).

Note icarus had problems with streaming operators:

    {<<{field_storage.rw_reg_lsb0.f1.value}}

Just like is currently being reported in xcelium for regblock,   #[165](https://github.com/SystemRDL/PeakRDL-regblock/issues/165).