### PR TITLE
Allow environment variables in configuration file

### DIFF
--- a/peakrdl-cli/src/peakrdl/config/loader.py
+++ b/peakrdl-cli/src/peakrdl/config/loader.py
@@ -96,6 +96,7 @@ def load_cfg(path: Optional[str]) -> AppConfig:
         path = ""
     else:
         # Found file. Parse it
+        path = os.path.expandvars(path)
         if not os.path.isfile(path):
             raise ValueError(f"error: invalid config file path: {path}")
 


### PR DESCRIPTION
Allow environment variables for the python_search_paths options in the configuration file