### PR TITLE
docs(community): add Editor Integrations section with systemrdl-pro

### DIFF
--- a/docs/community.rst
+++ b/docs/community.rst
@@ -133,3 +133,22 @@ Format Converters
     *   - `PeakRDL-opentitan <https://risto97.github.io/PeakRDL-opentitan/>`_
         - `Risto Pejašinović <https://github.com/Risto97>`_
         - Convert to and from OpenTitan hjson format
+
+
+Editor Integrations
+-------------------
+
+.. list-table::
+    :header-rows: 1
+
+    *   - Tool
+        - Author
+        - Summary
+
+    *   - `systemrdl-pro <https://github.com/seimei-d/systemrdl-pro>`_
+        - `seimei-d <https://github.com/seimei-d>`_
+        - VS Code extension and standalone LSP server for SystemRDL 2.0.
+          Provides diagnostics, hover, goto-definition, references, CodeLens,
+          inlay hints, and an interactive memory-map viewer. Built on
+          systemrdl-compiler. Editor-agnostic LSP so other editors can adopt it.
+          Also published on `Open VSX <https://open-vsx.org/extension/seimei-d/systemrdl-pro>`_.


### PR DESCRIPTION
Per https://github.com/orgs/SystemRDL/discussions/327, adding `systemrdl-pro` to the community page under a new **Editor Integrations** section.

Notes:

- New section uses **Tool** as the column header instead of **Plugin**, since editor integrations aren't PeakRDL plugins per se. Happy to change to **Plugin** if you prefer consistency with the other sections.
- The intro paragraph (*"Below is a list of other PeakRDL plugins..."*) is slightly inaccurate now that there's a non-plugin section. I left it as-is so you can pick the phrasing you want — let me know if you'd like me to update it in this PR.